### PR TITLE
Work around JRuby bug when DateTime fields are nil.

### DIFF
--- a/lib/mongoid/matchers/default.rb
+++ b/lib/mongoid/matchers/default.rb
@@ -33,6 +33,8 @@ module Mongoid #:nodoc:
       # @since 1.0.0
       def matches?(value)
         attribute.is_a?(Array) && !value.is_a?(Array) ? attribute.include?(value) : value === attribute
+      rescue
+        false # in JRuby, if value is a Time and attribute is nil, an exception is raised (this is likely a JRuby bug)
       end
 
       protected


### PR DESCRIPTION
When matching a Time field, if the attribute value is nil, do not raise an
exception, but instead return false.
