### PR TITLE
Added micro seconds to Time#local

### DIFF
--- a/lib/mongoid/fields/internal/timekeeping.rb
+++ b/lib/mongoid/fields/internal/timekeeping.rb
@@ -90,8 +90,7 @@ module Mongoid #:nodoc:
             when ::String
               time.parse(value)
             when ::DateTime
-              return value if value.utc? && Mongoid.use_utc?
-              time.local(value.year, value.month, value.day, value.hour, value.min, value.sec)
+              time.local(value.year, value.month, value.day, value.hour, value.min, value.sec, value.sec_fraction * 1_000_000)
             when ::Date
               time.local(value.year, value.month, value.day)
             when ::Array


### PR DESCRIPTION
Previously, when setting a DateTime attribute on one of our documents with a DateTime object with microseconds, Mongoid would truncate the microseconds. Now, it keeps them and no longer immediately returns if the DateTime object just because it's in UTC because otherwise it would still truncate the microseconds.
