### PR TITLE
Accounting for utc or local time

### DIFF
--- a/lib/mongoid/fields/internal/timekeeping.rb
+++ b/lib/mongoid/fields/internal/timekeeping.rb
@@ -90,7 +90,8 @@ module Mongoid #:nodoc:
             when ::String
               time.parse(value)
             when ::DateTime
-              time.local(value.year, value.month, value.day, value.hour, value.min, value.sec, value.sec_fraction * 1_000_000)
+              time.public_send(value.utc? ? :utc : :local,
+                               value.year, value.month, value.day, value.hour, value.min, value.sec, value.sec_fraction * 1_000_000)
             when ::Date
               time.local(value.year, value.month, value.day)
             when ::Array


### PR DESCRIPTION
Only using Time#local would interpret the time passed in as local time, so giving it a time object that is already in UTC like `2015-05-13 13:48:15 -0000` would turn in into `2015-05-13 18:48:15 -0000`.

So we have to determine if the value is already in utc and use the corresponding Time#gm method to interpret it correctly, else we use Time#local.
